### PR TITLE
Add whole-repo audit scope, census-not-incident, Phase 0 absorb, and optional CI automation

### DIFF
--- a/docs/skill.md
+++ b/docs/skill.md
@@ -21,6 +21,12 @@ Beyond the subcommands, once a project has Guider-authored standards the skill
 applies them to **every** change: descriptive names, surgical diffs, enums over
 string literals, DTO boundaries, transactions around critical writes, and so on.
 
+`/guider audit` can also run unattended: `init` offers an *optional* GitHub
+Actions mode that comments the audit automatically on every PR, so nobody has
+to remember to run it by hand. It's entirely opt-in and needs exactly one
+repo secret (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`) — standalone use
+of the subcommands needs none of it. See `references/ci-automation.md`.
+
 ## The documents Guider maintains
 
 Guider keeps a short, tool-neutral entry point and routes detail into siblings,

--- a/skill-src/guider/SKILL.md
+++ b/skill-src/guider/SKILL.md
@@ -81,16 +81,25 @@ Do **not** start writing files. Read `references/init-flow.md` and follow it
 end to end. The short version: detect greenfield vs. brownfield, inventory the
 stack, report what you found, interview the user on the gaps, confirm, then
 generate docs and gates. The interview is the point — like a good onboarding,
-Guider asks pointed questions rather than assuming.
+Guider asks pointed questions rather than assuming. Running `/guider audit`
+by hand is always enough on its own — `init` also offers an *optional* CI mode
+that comments the audit automatically on every PR; see
+`references/ci-automation.md` if the user wants it.
 
 ## When the user runs `/guider audit`
 
 Do **not** change anything — an audit is read-only. Read
 `references/audit-flow.md` and follow it end to end: establish the contract
-(the project's Guider docs, falling back to the defaults), scan the codebase by
-area, and print a precise findings report where every finding is anchored to a
-`file:line`, cites the rule it breaks, names a concrete resolution, and is tagged
-`safe` or `risky`. Then stop and point the user at `/guider fix`.
+(the project's Guider docs, falling back to the defaults), scan the whole
+repository by area — including migrations, scripts, docs, and data artifacts,
+not just conventionally-shaped source files — folding in any findings handed
+to it from elsewhere (a pasted incident, another agent's investigation, a
+`/code-review`/`/security-review` pass), and print a precise findings report
+where every finding is anchored to a `file:line` (or a data location), cites
+the rule it breaks, names a concrete resolution, and is tagged `safe` or
+`risky`. A finding that names a real pattern gets swept against its full
+population, not just the instances already known. Then stop and point the
+user at `/guider fix`.
 
 ## When the user runs `/guider fix`
 

--- a/skill-src/guider/assets/templates/guider-audit.yml.tmpl
+++ b/skill-src/guider/assets/templates/guider-audit.yml.tmpl
@@ -1,0 +1,95 @@
+# guider-audit.yml.tmpl — filled by `/guider init` Phase 5, only if the user
+# opted into CI automation during Phase 3 (see `references/ci-automation.md`
+# for the full explanation and `references/init-flow.md` step 9 for how to
+# fill this). Standalone use of `/guider audit`/`/guider fix` etc. inside a
+# Claude Code session needs NONE of this file — it's an optional add-on, not
+# a prerequisite.
+#
+# Filling checklist (see ci-automation.md for detail on each):
+#   - Keep exactly ONE of the two `with:` auth lines below; delete the other.
+#   - Fill {{PLUGIN_MARKETPLACE_URL}} and {{MARKETPLACE_NAME}} from the repo/
+#     name this Claude Code session actually loaded `guider` from.
+#   - Delete the `allowed_bots` line entirely if this repo has no bot-opened
+#     PRs (the common case) — don't leave it commented out.
+#   - Only add the private-marketplace cross-repo-token steps (documented in
+#     `ci-automation.md`, "If your marketplace repo is private") if the
+#     interview confirmed that repo is actually private. Most projects won't
+#     need them — skip by default.
+#   - Write the result to this project's own workflow directory (usually
+#     `.github/workflows/`, confirm rather than assume) and delete this
+#     header comment once filled.
+name: Guider audit (advisory)
+
+# Runs the `guider` skill's /guider audit against just this PR's diff and
+# posts the findings as a comment. Advisory only — `contents: read` (no
+# write) means this job physically cannot push a commit or edit a file, so
+# it can never block or alter the PR; it only reports. `id-token: write` is
+# unrelated to that guarantee: it's Anthropic's own recommended default for
+# claude-code-action (some auth/plugin paths use it, some don't; granting it
+# is harmless either way — it does not add any repo/content access).
+#
+# Requires (set up once, by a repo admin — not done by this workflow):
+#   Secrets and variables > Actions > New repository secret > the ONE
+#   secret matching whichever auth line is kept below (ANTHROPIC_API_KEY
+#   or CLAUDE_CODE_OAUTH_TOKEN).
+#
+# guider itself is a Claude Code plugin, sourced from a marketplace repo
+# ({{PLUGIN_MARKETPLACE_URL}}). This workflow loads it directly from there so
+# CI doesn't depend on org-level plugin provisioning (org-wide Claude Plugin
+# provisioning is tied to an authenticated claude.ai session — a GitHub
+# Actions runner has no such session, so it can't see it even if your org
+# has the plugin installed for everyone). If that marketplace repo is
+# PRIVATE, this clone needs its own credentials — see
+# references/ci-automation.md ("If your marketplace repo is private");
+# skip that entirely if it's public.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: guider-audit-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guider-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          # Pick ONE of the two auth lines below (delete the other):
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Only needed if PRs in this repo are sometimes opened by a bot
+          # account — without it, claude-code-action refuses to run on PRs
+          # opened by a non-human actor ("Workflow initiated by non-human
+          # actor"). Name it explicitly (never "*", which trusts any bot):
+          # allowed_bots: "{{BOT_NAME}}[bot]"
+
+          plugin_marketplaces: "{{PLUGIN_MARKETPLACE_URL}}"
+          plugins: "guider@{{MARKETPLACE_NAME}}"
+          prompt: |
+            Run /guider:guider audit, scoped ONLY to the files changed in
+            this pull request (diff this branch against the PR base branch —
+            do not audit the rest of the repository).
+
+            Post the findings report as a single PR comment on
+            ${{ github.repository }}#${{ github.event.pull_request.number }}.
+
+            This is advisory only: do NOT run /guider:guider fix, do NOT
+            edit any files, do NOT create commits — you have no write access
+            to contents anyway. If the audit finds nothing, post a short
+            comment saying so instead of staying silent.
+          claude_args: |
+            --max-turns 50

--- a/skill-src/guider/references/audit-flow.md
+++ b/skill-src/guider/references/audit-flow.md
@@ -44,6 +44,96 @@ is large and no scope was given, say what you're covering (and what you're
 skipping, e.g. generated code, vendored deps, `node_modules`) rather than
 silently sampling.
 
+**"Whole repository" means every file, not just the ones shaped like
+`conventions.md`'s examples.** It's tempting to scan the files that look like the
+areas below — services, controllers, components — and skip the rest because
+they don't fit a familiar pattern. That's exactly how real defects hide. Unless
+explicitly scoped away, also read:
+
+- **Migrations / schema / seed SQL** — idempotency, destructive statements
+  without a guard, a column added in code but never in the migration.
+- **Scripts, one-off tooling, `Makefile`/CI YAML** — the same conventions apply
+  to a script that runs in prod as to application code.
+- **Data snapshots, fixtures, backups checked into the repo** (`*.json`,
+  `*.csv` dumps) — a stale snapshot, or one that reveals a fix never
+  generalized (see "Census, not incident" below).
+- **Planning/incident docs** (`docs/*.md`, `PLAN*.md`, postmortems) — these
+  often *state* a rule was generalized while the linked remediation only
+  touched the named instances. Read the remediation, not just the prose.
+- **If the project persists state in a database**, treat the live data itself
+  as something to audit, not just the code that writes it — see "Census, not
+  incident."
+
+Don't let "audit the whole repository" quietly narrow to "audit the files that
+look auditable."
+
+## Census, not incident
+
+Bound this before applying it: it's for **medium/high severity** findings — a
+real invariant violation, a broken-its-own-rule contract violation — not every
+stylistic or advisory pattern. A low-severity nit that happens to repeat twice
+doesn't earn a full-repo grep or a whole-table scan; note that other instances
+likely exist and move on. This is a bigger flashlight for real problems, not a
+mandate to boil the ocean on every finding.
+
+The common way a real finding under-delivers: it correctly diagnoses a *class*
+of problem and states the general rule in prose — then the actual check (or,
+downstream, the fix) only touches the specific instance(s) that surfaced it.
+The rule reads as generalized; the remediation reads as one-off.
+
+For a medium/high finding that describes a pattern (not a one-off typo):
+
+- **Attempt the sweep before filing the finding.** Code pattern → grep/search
+  the **entire** scope (see above) for other occurrences of the same shape,
+  not only the file(s) where it was first spotted. Data pattern → run a
+  **read-only** query across the **whole** table/collection for the
+  invariant, not just the rows a known incident already named.
+- **Report the delta**: "N total instances found (M already known from the
+  reported incident, N−M new)."
+- Only mark a finding "incomplete (not swept)" when the read-only tooling to
+  do the sweep genuinely isn't available in this session — never as a
+  substitute for a grep/query you could have run.
+- Dead data left by removed code (a legacy marker, an orphaned enum/`source`
+  value) is not an exemption — rows carrying it still count toward a census
+  sweep for a currently-live invariant; don't treat "this came from an old
+  code path" as "already handled."
+- If the sweep is a full-table scan against a large or live production
+  database, bound it (a row-count check first, a `LIMIT`/sample, a read
+  replica if one exists) or flag the cost and confirm before running it —
+  read-only doesn't mean free.
+
+This is inspection only — sweeping means searching and querying, never
+writing.
+
+---
+
+## Phase 0 — absorb findings from elsewhere (optional)
+
+`/guider audit` doesn't have to start from a blank scan. The user may hand it
+findings that came from somewhere else — a pasted incident writeup, another
+agent's investigation, a `/code-review` or `/security-review` pass, a
+production bug report. Treat each one exactly like a self-found violation, not
+a fait accompli to rubber-stamp:
+
+1. **Establish the contract first** (Phase 1) if you haven't already —
+   restating a finding as a rule means citing the convention it breaks, which
+   requires knowing what the project's docs (or the defaults) actually say.
+2. **Restate it as a rule**, the same way any other finding cites the
+   convention it breaks (Phase 3's `rule` field). If the source already
+   generalized it, use that generalization; if it only described the specific
+   instance, generalize it yourself.
+3. **Sweep for it** (see "Census, not incident" above, same severity bar) —
+   the point of folding an external finding in is to check whether it's
+   actually contained to the reported instance(s) or wider.
+4. **Fold it into the same structured report** as Phase 3 shapes below, so
+   `/guider fix` can act on it identically to anything the audit found on its
+   own — no separate track, no special-casing.
+
+This is also how a codebase's contract grows over time: an issue found once,
+by any means, becomes a rule the *next* audit checks for automatically (see
+`fix-flow.md`'s recording step) — instead of being refought each time it
+resurfaces under a new name.
+
 ---
 
 ## Phase 1 — Establish the contract
@@ -108,6 +198,22 @@ area, the recurring violations to grep for and reason about:
 - Tenant-scoped tables relying on `WHERE` filters instead of RLS, where the docs
   say isolation matters.
 - External API calls with no retry/backoff; a swallowed timeout.
+- A documented data invariant (a column that must never be null, an entity
+  that must have exactly one related X, two states that must never coexist)
+  checked only against the rows a known incident named, never swept against
+  the full table — see "Census, not incident."
+- Dead data left behind by removed code — an enum value, a `source`/`type`
+  marker, a column a since-deleted function used to populate — that a reader
+  could mistake for still-live behavior.
+
+**Migrations, scripts & data artifacts** (`data-integrity.md`, "Census, not incident" above)
+- A migration or seed script held to a looser standard than application
+  code — no idempotency guard, a destructive statement with no safety check.
+- A plan/incident doc whose prose generalizes a rule but whose linked
+  remediation only ever touches the originally-named instance(s) — the
+  incident-vs-census gap itself.
+- A data snapshot/fixture/backup checked into the repo that's stale, or that
+  documents a fix which was never swept against the rest of the table.
 
 **Runtime infrastructure** (`infrastructure.md`)
 - Cache entries set with no TTL; cache updated in place on write instead of
@@ -159,11 +265,18 @@ Every finding carries exactly these fields, so `fix` can act on it mechanically:
 - **resolution** — the precise change to make, concrete enough to apply without
   re-deciding. Name the helper/enum/constant to use if one already exists.
 - **risk** — `safe` for mechanical, behavior-preserving edits (renames, enum
-  extraction, adding a TTL, magic-string→constant, DTO mapping, DI wiring), or
-  `risky` for anything touching a DB migration, RLS policy, behavior-changing
-  transaction wrapping, schema, or encryption. **This field decides how `fix`
-  treats the finding** — `fix` applies `safe` automatically and pauses on
-  `risky` — so classify deliberately.
+  extraction, adding a TTL, magic-string→constant, DTO mapping, DI wiring,
+  recording a generalized rule in the project's contract docs — see
+  `fix-flow.md`'s "Closing the loop"), or `risky` for anything touching a DB
+  migration, RLS policy, behavior-changing transaction wrapping, schema, or
+  encryption. **This field decides how `fix` treats the finding** — `fix`
+  applies `safe` automatically and pauses on `risky` — so classify deliberately.
+
+For a finding shaped by "Census, not incident," put the sweep result in
+**location** (e.g. "src/lib/foo.ts:42, and 11 more — see list" or "23 rows
+beyond the 4 named in the incident, `users` table") rather than inventing a
+new field — the shape stays the same for every finding, whether self-found or
+absorbed via Phase 0.
 
 ---
 
@@ -173,6 +286,11 @@ Print the findings to the conversation, grouped by area, with each field above.
 Lead with a one-paragraph summary: total findings, the count by severity, and
 the count by risk class (`safe` vs `risky`) — that breakdown previews exactly how
 much `/guider fix` will apply automatically versus gate.
+
+For any finding shaped by "Census, not incident" or absorbed via Phase 0,
+state what was swept — the query/grep and its scope — and the resulting
+count, not just the finding itself. That's the evidence the sweep actually
+happened rather than being asserted.
 
 Close by telling the user they can run **`/guider fix`** to apply the
 resolutions (safe ones automatically, risky ones with confirmation), or scope it.

--- a/skill-src/guider/references/ci-automation.md
+++ b/skill-src/guider/references/ci-automation.md
@@ -1,0 +1,110 @@
+# CI automation — running `/guider audit` on every PR (optional)
+
+Guider works two ways, and neither is "more correct" than the other — pick per
+project:
+
+- **Standalone.** Run `/guider init`, `/guider audit`, `/guider fix`, `/guider
+  spec` interactively inside a Claude Code session, whenever you want them.
+  This is the whole skill; nothing in this file is required to use it. See the
+  skill's `README.md`, "How to install it", for the two ways to get the skill
+  itself into a session (org Plugin with GitHub auto-sync, or a manual
+  `.skill` upload).
+- **CI-automated.** A GitHub Actions job runs `/guider audit` on every PR and
+  posts the findings as a comment automatically — nobody has to remember to
+  run it. This file documents that mode: what it needs, what it doesn't, and
+  the one thing that changes if your plugin's marketplace repo is private.
+
+Offer the CI-automated mode during `/guider init` (Phase 3 asks; Phase 5
+scaffolds it if the user opts in — see `init-flow.md`). It can also be added
+by hand at any time by following this file directly.
+
+## What it needs — exactly one secret, nothing else
+
+The workflow uses `anthropics/claude-code-action`, which needs ONE of:
+
+- `ANTHROPIC_API_KEY` — an API key from [console.anthropic.com](https://console.anthropic.com).
+- `CLAUDE_CODE_OAUTH_TOKEN` — for Claude Pro/Max subscribers, generated locally
+  via `claude setup-token`. No separate API billing.
+
+Either one goes in the repo's **Settings → Secrets and variables → Actions →
+New repository secret**, under whichever name matches the auth line the
+template kept (see below). Propose the exact command for the user to run
+themselves — never ask for the raw secret value in chat, and never run the
+`gh secret set`/equivalent command with the value already filled in:
+
+```bash
+gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
+# — or, for the OAuth token —
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo <owner>/<repo>
+```
+
+That's the entire requirement. Nothing else is universal — the rest of this
+file covers one conditional case (a private marketplace repo) that most
+projects won't hit.
+
+## Filling the template
+
+Use `assets/templates/guider-audit.yml.tmpl`. It needs four answers from the
+interview (Phase 3 of `init-flow.md`):
+
+1. **Which auth secret** — `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`.
+   Keep only the matching `with:` line in the template; delete the other.
+2. **The plugin's marketplace source** — the GitHub repo URL and marketplace
+   name this Claude Code session actually loaded `guider` from (check
+   `.claude-plugin/marketplace.json` in that repo for the `name` field if
+   unsure — it's the `{{MARKETPLACE_NAME}}` half of `plugins:
+   "guider@{{MARKETPLACE_NAME}}"`). This is very likely the same repo the user
+   just installed the skill from (`README.md`, "How to install it", Option A).
+3. **Does this repo have bot-opened PRs?** If yes, name the bot account and
+   keep the `allowed_bots` line; if no (the common case), delete that line
+   entirely rather than commenting it out.
+4. **Where do this project's other workflows live?** — usually
+   `.github/workflows/`, but confirm rather than assume.
+
+Write the filled file, then stop — same as every other `init` gate: propose
+the secret-creation command, don't run it.
+
+## If your marketplace repo is private
+
+`claude-code-action`'s `plugin_marketplaces` input does a plain `git clone` of
+that URL at job runtime. A **public** repo just works — nothing more to do. A
+**private** one needs its own credentials, because the workflow's default
+`GITHUB_TOKEN` is scoped only to the repo the workflow lives in, never to a
+different repo — even a private one in the same org.
+
+This is a real but narrow case (a team maintaining its own private fork of the
+plugin, mid-review before publishing it, say) — don't scaffold it by default;
+only reach for it if the interview confirms the marketplace repo is actually
+private. When it applies, the standard fix is a scoped GitHub App installation
+token, generated fresh in the job and handed to git via a URL rewrite so
+`claude-code-action`'s internal clone picks it up transparently without
+needing to know any of this exists:
+
+```yaml
+- name: Create marketplace token (private marketplace repo)
+  id: marketplace-token
+  uses: actions/create-github-app-token@v3
+  with:
+    app-id: "{{GITHUB_APP_ID}}"
+    private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} # name the secret whatever you like; update this reference to match
+    owner: "{{MARKETPLACE_OWNER}}"
+    repositories: "{{MARKETPLACE_REPO_NAME}}"
+
+- name: Let git use that token for github.com clones (the marketplace fetch)
+  run: git config --global url."https://x-access-token:${{ steps.marketplace-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+```
+
+Insert these two steps between `checkout` and the `claude-code-action` step.
+Requires a GitHub App already installed with read access to the marketplace
+repo, and its private key added as one more repo secret (same
+propose-don't-run rule as above). Once the marketplace repo goes public, strip
+these two steps back out — they stop doing anything useful and are just
+complexity to maintain.
+
+## Per-CI-provider note
+
+This specific automated mode is GitHub Actions-only — `claude-code-action` is
+a GitHub Action. On another CI provider, the standalone mode (run the
+`/guider` commands interactively, or script the Claude Code CLI directly in
+whatever job runner you have) still works fine; only the "auto-comment on
+every PR via this exact plugin action" convenience is GitHub-specific.

--- a/skill-src/guider/references/data-integrity.md
+++ b/skill-src/guider/references/data-integrity.md
@@ -101,3 +101,27 @@ source, which operations are transactional, which are idempotent and where the
 keys come from, and the retry/cache policy for each external integration. The
 point is that the next person — or the next Claude — can see the guarantees
 without reverse-engineering them from the code.
+
+## Auditing existing data — census, not incident
+
+Everything above is about guaranteeing integrity going forward — RLS,
+transactions, idempotency for new writes. None of it tells you whether data
+already in the table honors those guarantees today. It often doesn't: a
+guarantee added later doesn't retroactively fix rows written before it
+existed, and a one-off incident fix tends to repair only the row(s) that
+paged someone.
+
+When auditing (not building) a system with persisted state:
+
+- Treat a documented invariant ("a user has exactly one primary email", "an
+  order never has both a refund and a pending charge") as something to check
+  against the **actual data**, with a read-only query across the whole
+  table — not just the rows a bug report already named.
+- A finding that generalizes the rule in its writeup but only remediates the
+  originally-reported rows is incomplete — the gap between "rows we know
+  about" and "rows that actually violate the rule" is usually where the next
+  incident comes from.
+- Report the delta explicitly: how many rows violate the invariant in total,
+  versus how many were already known. See `audit-flow.md`'s "Census, not
+  incident" for how this shapes the finding (including the severity bar and
+  the production-query cost caveat).

--- a/skill-src/guider/references/fix-flow.md
+++ b/skill-src/guider/references/fix-flow.md
@@ -81,6 +81,36 @@ change.
 
 ---
 
+## Closing the loop — record generalized rules durably
+
+A finding that came from "Census, not incident" (`audit-flow.md`) or was
+absorbed from an external source (Phase 0 there) is, by definition,
+medium/high severity — and represents more than the instances just fixed:
+it's a rule the project didn't have written down before. Once its
+resolutions are applied (including any `risky` ones the user approved),
+record the generalization as its own `safe` action (per `audit-flow.md`'s
+Phase 3 risk taxonomy) in the project's own contract docs:
+
+- If the project's `AGENTS.md` (or a `CLAUDE.md` that imports it, or a
+  sibling like `ARCHITECTURE.md`) already keeps a running list of hard-won
+  rules/invariants, add one entry there in the same voice and format the
+  existing entries use — cite the concrete incident that surfaced it and
+  state the general rule, the same way the existing entries do.
+- If no such section exists yet, don't invent a new doc format for one
+  finding; add a short "Lessons" section to `ARCHITECTURE.md` (or wherever
+  `/guider init` would have put it) and note that future entries should
+  accumulate there.
+- Low-severity findings that only got a lightweight sweep note (not a full
+  census) don't get a durable entry — this is for the real, medium/high
+  rules, not every observation.
+
+The payoff: the next `/guider audit` reads this doc in its own Phase 1 ("read
+the project's own docs") — so a rule learned once, from any source, is
+checked for automatically from then on, instead of relying on someone
+remembering to re-flag it.
+
+---
+
 ## Phase 4 — Summary
 
 Close with a clear ledger:

--- a/skill-src/guider/references/init-flow.md
+++ b/skill-src/guider/references/init-flow.md
@@ -137,6 +137,17 @@ Cover these, skipping any the scan already answered:
 - Secret-leak scanning: confirm adding it if absent.
 - CI provider, if not detected.
 
+**CI automation (optional)** — only ask if the CI provider is GitHub Actions
+(this specific mode is GitHub-specific; see `ci-automation.md`)
+- Want `/guider audit` to run automatically on every PR and post the findings
+  as a comment, instead of (or in addition to) running it by hand? If yes,
+  gather the four things `ci-automation.md`'s template needs: which auth
+  secret they'll use (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`), the
+  marketplace repo + name this session's `guider` was actually loaded from,
+  whether this repo has bot-opened PRs (and if so, the bot's name), and where
+  its other workflows live. If no, skip the rest of this round entirely — it's
+  opt-in, not a default.
+
 **API documentation**
 - If there's an HTTP API and no generated OpenAPI spec (or a hand-written one
   that can drift), propose setting it up the Guider way: generated from the code
@@ -161,6 +172,8 @@ Before writing anything, lay out exactly what you'll create or change:
   `APPLICATION.md`, any extras) and the headline content of each;
 - which gates you'll scaffold (formatter/linter config, pre-commit hooks,
   secret scan, CI workflow) and which already exist and will be left alone;
+- whether you're adding the optional CI-automated `/guider audit` workflow
+  (`ci-automation.md`), if the user opted in;
 - the Karpathy merge into `AGENTS.md`;
 - the recommended managed services (Upstash for cache, Trigger.dev for workers,
   Pusher for realtime) where they fit, and the Impeccable recommendation.
@@ -219,7 +232,16 @@ Now write, using the templates in `assets/templates/`. Rules:
    existing alternative the project already uses) in `ARCHITECTURE.md` with its
    TTL / retry / idempotency / missed-message policy. Don't provision or install
    anything — name the next step for the user.
+9. **Scaffold the CI-automated audit workflow** only if the user opted in
+   (`ci-automation.md`). Fill `assets/templates/guider-audit.yml.tmpl` from the
+   interview answers and write it to the project's workflow directory — keep
+   only the one auth line (`anthropic_api_key` or `claude_code_oauth_token`)
+   that matches their answer, delete the `allowed_bots` line entirely if they
+   have no bot-opened PRs, and only add the private-marketplace cross-repo
+   token steps if they confirmed that repo is private. Propose the
+   secret-creation command; never run it or ask for the raw value.
 
 Finish with a short summary: the files created/edited, the commands the user
-should run to activate the gates (install hooks, enable CI), and the one or two
-follow-ups worth doing next. Then stop — don't keep generating.
+should run to activate the gates (install hooks, enable CI, add the secret if
+step 9 applied), and the one or two follow-ups worth doing next. Then stop —
+don't keep generating.


### PR DESCRIPTION
Hi Adrian — thanks for sending me the skill source a while back. I've been running it on a real production codebase and picked up a few things along the way that I think are worth contributing back. I know your `main` has moved on since then (the AGENTS.md/Codex-neutral rework is great) — I re-read every file I touched against your *current* version before writing anything, so nothing here duplicates what you've already done independently, and nothing reverts the AGENTS.md-primary architecture.

## What's in this PR

**Three additions to how `/guider audit` handles real (not toy) codebases:**

- **`audit-flow.md` — "whole repository" made explicit.** It's easy for "audit the whole repo" to quietly narrow to "audit the files shaped like the examples in `conventions.md`." Spells out that migrations/seed SQL, scripts, CI YAML, data snapshots/fixtures, and planning/incident docs are in scope too, unless explicitly scoped away.
- **`audit-flow.md` + `data-integrity.md` — "Census, not incident."** The failure mode I kept running into: a finding correctly diagnoses a *class* of problem and states the general rule in prose, but the actual remediation only touches the specific row(s)/instance(s) a bug report already named. This adds a sweep step for medium/high findings — grep the whole scope, or run a read-only query across the whole table — and requires reporting the delta ("N total, M already known, N−M new"). Bounded so it doesn't turn every nit into a full-table scan.
- **`audit-flow.md` — Phase 0, absorb findings from elsewhere (optional).** Lets `/guider audit` take a finding from anywhere (a pasted incident, another agent's investigation, a `/code-review` pass) and fold it into the same structured report — generalize it, sweep it, act on it identically to a self-found one.
- **`fix-flow.md` — Closing the loop.** Once a census/Phase-0 finding is resolved, record the generalized rule durably in the project's own contract docs (`AGENTS.md`/`CLAUDE.md` importer/`ARCHITECTURE.md`), so the *next* audit checks for it automatically instead of it being rediscovered under a new name.

**A new, fully optional feature — CI-automated `/guider audit`:**

Before this, the only way to run `/guider audit` was interactively. `init` can now offer (opt-in, asked during the interview) to scaffold a GitHub Actions job that runs it on every PR and posts the findings as a comment automatically — nobody has to remember. It needs exactly one repo secret (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`) and nothing else; standalone use of the subcommands is completely unaffected. New `references/ci-automation.md` + `assets/templates/guider-audit.yml.tmpl` — the template is fully generic, every project-specific value is a placeholder the interview fills in.

## Verification

- Read every file this touches in full (current `main`, not a stale copy) before editing, to confirm nothing duplicates content you've already added and nothing reverts the AGENTS.md/Codex-neutral rework — every new line that references your entry-point docs uses your current phrasing verbatim.
- Had an independent review pass check specifically for: architecture reversion, content duplication, voice/terminology consistency, leaked project-specific values in the new CI files, unrelated file changes, and cross-reference correctness.
- `npm test` (20/20), `npm run lint`, and `npm run build` all pass unmodified — confirmed the new files package correctly into `dist/guider.skill` too.

Happy to adjust anything that doesn't fit where you've taken this since. Thanks again for building this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)