### PR TITLE
fix(skill): rework CI-automation around the CLI, not a plugin marketplace (closes #3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adrianfsf/guider",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "CLI to install and manage coding-agent skills for Claude and Codex (ChatGPT).",
   "type": "module",
   "bin": {

--- a/skill-src/guider/assets/templates/guider-audit.yml.tmpl
+++ b/skill-src/guider/assets/templates/guider-audit.yml.tmpl
@@ -5,43 +5,31 @@
 # Claude Code session needs NONE of this file — it's an optional add-on, not
 # a prerequisite.
 #
+# How it loads guider: this workflow installs the guider skill straight from
+# npm into the checked-out workspace's `.claude/skills/` directory, then
+# `claude-code-action` discovers it there automatically (project skills are
+# picked up from `.claude/skills/`). No plugin marketplace, no extra auth for
+# the skill itself — it's the same public CLI + release asset anyone installs
+# with (`npx @adrianfsf/guider skills install guider`).
+#
 # Filling checklist (see ci-automation.md for detail on each):
 #   - Keep exactly ONE of the two `with:` auth lines below; delete the other.
-#   - Fill {{PLUGIN_MARKETPLACE_URL}} and {{MARKETPLACE_NAME}} from the repo/
-#     name this Claude Code session actually loaded `guider` from.
 #   - Delete the `allowed_bots` line entirely if this repo has no bot-opened
 #     PRs (the common case) — don't leave it commented out.
-#   - Only add the private-marketplace cross-repo-token steps (documented in
-#     `ci-automation.md`, "If your marketplace repo is private") if the
-#     interview confirmed that repo is actually private. Most projects won't
-#     need them — skip by default.
 #   - Write the result to this project's own workflow directory (usually
 #     `.github/workflows/`, confirm rather than assume) and delete this
 #     header comment once filled.
 name: Guider audit (advisory)
 
-# Runs the `guider` skill's /guider audit against just this PR's diff and
-# posts the findings as a comment. Advisory only — `contents: read` (no
-# write) means this job physically cannot push a commit or edit a file, so
-# it can never block or alter the PR; it only reports. `id-token: write` is
-# unrelated to that guarantee: it's Anthropic's own recommended default for
-# claude-code-action (some auth/plugin paths use it, some don't; granting it
-# is harmless either way — it does not add any repo/content access).
+# Runs the `guider` skill's /guider audit against just this PR's diff and posts
+# the findings as a comment. Advisory only — `contents: read` (no write) means
+# this job physically cannot push a commit or edit a file, so it can never block
+# or alter the PR; it only reports.
 #
 # Requires (set up once, by a repo admin — not done by this workflow):
-#   Secrets and variables > Actions > New repository secret > the ONE
-#   secret matching whichever auth line is kept below (ANTHROPIC_API_KEY
-#   or CLAUDE_CODE_OAUTH_TOKEN).
-#
-# guider itself is a Claude Code plugin, sourced from a marketplace repo
-# ({{PLUGIN_MARKETPLACE_URL}}). This workflow loads it directly from there so
-# CI doesn't depend on org-level plugin provisioning (org-wide Claude Plugin
-# provisioning is tied to an authenticated claude.ai session — a GitHub
-# Actions runner has no such session, so it can't see it even if your org
-# has the plugin installed for everyone). If that marketplace repo is
-# PRIVATE, this clone needs its own credentials — see
-# references/ci-automation.md ("If your marketplace repo is private");
-# skip that entirely if it's public.
+#   Secrets and variables > Actions > New repository secret > the ONE secret
+#   matching whichever auth line is kept below (ANTHROPIC_API_KEY or
+#   CLAUDE_CODE_OAUTH_TOKEN).
 
 on:
   pull_request:
@@ -50,7 +38,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 concurrency:
   group: guider-audit-${{ github.event.pull_request.number }}
@@ -65,6 +52,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Install the guider skill into this workspace so claude-code-action
+      # discovers it under .claude/skills/guider. Pin the version (e.g.
+      # @adrianfsf/guider@1.2.0) instead of @latest for reproducible CI.
+      - name: Install the guider skill
+        run: npx -y @adrianfsf/guider@latest skills install guider --project
+
       - uses: anthropics/claude-code-action@v1
         with:
           # Pick ONE of the two auth lines below (delete the other):
@@ -77,19 +70,18 @@ jobs:
           # actor"). Name it explicitly (never "*", which trusts any bot):
           # allowed_bots: "{{BOT_NAME}}[bot]"
 
-          plugin_marketplaces: "{{PLUGIN_MARKETPLACE_URL}}"
-          plugins: "guider@{{MARKETPLACE_NAME}}"
           prompt: |
-            Run /guider:guider audit, scoped ONLY to the files changed in
-            this pull request (diff this branch against the PR base branch —
-            do not audit the rest of the repository).
+            Run the guider skill's audit (/guider audit), scoped ONLY to the
+            files changed in this pull request — diff this branch against the
+            PR base branch (${{ github.event.pull_request.base.ref }}); do not
+            audit the rest of the repository.
 
             Post the findings report as a single PR comment on
             ${{ github.repository }}#${{ github.event.pull_request.number }}.
 
-            This is advisory only: do NOT run /guider:guider fix, do NOT
-            edit any files, do NOT create commits — you have no write access
-            to contents anyway. If the audit finds nothing, post a short
-            comment saying so instead of staying silent.
+            Advisory only: do NOT run /guider fix, do NOT edit any files, do NOT
+            create commits — you have no write access to contents anyway. If the
+            audit finds nothing, post a short comment saying so instead of
+            staying silent.
           claude_args: |
             --max-turns 50

--- a/skill-src/guider/references/ci-automation.md
+++ b/skill-src/guider/references/ci-automation.md
@@ -5,18 +5,33 @@ project:
 
 - **Standalone.** Run `/guider init`, `/guider audit`, `/guider fix`, `/guider
   spec` interactively inside a Claude Code session, whenever you want them.
-  This is the whole skill; nothing in this file is required to use it. See the
-  skill's `README.md`, "How to install it", for the two ways to get the skill
-  itself into a session (org Plugin with GitHub auto-sync, or a manual
-  `.skill` upload).
+  This is the whole skill; nothing in this file is required to use it. Install
+  the skill with the CLI — `npx @adrianfsf/guider skills install guider` (see
+  the project `README.md` / `docs/installation.md`).
 - **CI-automated.** A GitHub Actions job runs `/guider audit` on every PR and
   posts the findings as a comment automatically — nobody has to remember to
-  run it. This file documents that mode: what it needs, what it doesn't, and
-  the one thing that changes if your plugin's marketplace repo is private.
+  run it. This file documents that mode: what it needs and what it doesn't.
 
 Offer the CI-automated mode during `/guider init` (Phase 3 asks; Phase 5
 scaffolds it if the user opts in — see `init-flow.md`). It can also be added
 by hand at any time by following this file directly.
+
+## How the workflow loads guider — no marketplace, no plugin
+
+The template installs the skill the exact same way a human does: with the
+public CLI, straight from npm, into the checked-out workspace.
+
+```yaml
+- name: Install the guider skill
+  run: npx -y @adrianfsf/guider@latest skills install guider --project
+```
+
+`--project` drops it in `./.claude/skills/guider`, and `claude-code-action`
+discovers project skills there automatically — so the job's `prompt: /guider
+audit` just works. There is no Claude Code plugin, no marketplace repo, and no
+extra credential for the skill itself: the release asset is public, so the
+install is anonymous. (Pin `@adrianfsf/guider@<version>` instead of `@latest`
+if you want reproducible CI.)
 
 ## What it needs — exactly one secret, nothing else
 
@@ -38,73 +53,34 @@ gh secret set ANTHROPIC_API_KEY --repo <owner>/<repo>
 gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo <owner>/<repo>
 ```
 
-That's the entire requirement. Nothing else is universal — the rest of this
-file covers one conditional case (a private marketplace repo) that most
-projects won't hit.
+That's the entire requirement — the skill install needs no secret at all.
+
+The workflow requests only `contents: read` and `pull-requests: write`: it can
+read the diff and post a comment, and physically cannot push a commit or edit a
+file. `id-token: write` is **not** needed (the action authenticates via a
+GitHub App, not OIDC) — don't grant it.
 
 ## Filling the template
 
-Use `assets/templates/guider-audit.yml.tmpl`. It needs four answers from the
+Use `assets/templates/guider-audit.yml.tmpl`. It needs three answers from the
 interview (Phase 3 of `init-flow.md`):
 
 1. **Which auth secret** — `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`.
    Keep only the matching `with:` line in the template; delete the other.
-2. **The plugin's marketplace source** — the GitHub repo URL and marketplace
-   name this Claude Code session actually loaded `guider` from (check
-   `.claude-plugin/marketplace.json` in that repo for the `name` field if
-   unsure — it's the `{{MARKETPLACE_NAME}}` half of `plugins:
-   "guider@{{MARKETPLACE_NAME}}"`). This is very likely the same repo the user
-   just installed the skill from (`README.md`, "How to install it", Option A).
-3. **Does this repo have bot-opened PRs?** If yes, name the bot account and
+2. **Does this repo have bot-opened PRs?** If yes, name the bot account and
    keep the `allowed_bots` line; if no (the common case), delete that line
    entirely rather than commenting it out.
-4. **Where do this project's other workflows live?** — usually
+3. **Where do this project's other workflows live?** — usually
    `.github/workflows/`, but confirm rather than assume.
 
 Write the filled file, then stop — same as every other `init` gate: propose
 the secret-creation command, don't run it.
-
-## If your marketplace repo is private
-
-`claude-code-action`'s `plugin_marketplaces` input does a plain `git clone` of
-that URL at job runtime. A **public** repo just works — nothing more to do. A
-**private** one needs its own credentials, because the workflow's default
-`GITHUB_TOKEN` is scoped only to the repo the workflow lives in, never to a
-different repo — even a private one in the same org.
-
-This is a real but narrow case (a team maintaining its own private fork of the
-plugin, mid-review before publishing it, say) — don't scaffold it by default;
-only reach for it if the interview confirms the marketplace repo is actually
-private. When it applies, the standard fix is a scoped GitHub App installation
-token, generated fresh in the job and handed to git via a URL rewrite so
-`claude-code-action`'s internal clone picks it up transparently without
-needing to know any of this exists:
-
-```yaml
-- name: Create marketplace token (private marketplace repo)
-  id: marketplace-token
-  uses: actions/create-github-app-token@v3
-  with:
-    app-id: "{{GITHUB_APP_ID}}"
-    private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} # name the secret whatever you like; update this reference to match
-    owner: "{{MARKETPLACE_OWNER}}"
-    repositories: "{{MARKETPLACE_REPO_NAME}}"
-
-- name: Let git use that token for github.com clones (the marketplace fetch)
-  run: git config --global url."https://x-access-token:${{ steps.marketplace-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-```
-
-Insert these two steps between `checkout` and the `claude-code-action` step.
-Requires a GitHub App already installed with read access to the marketplace
-repo, and its private key added as one more repo secret (same
-propose-don't-run rule as above). Once the marketplace repo goes public, strip
-these two steps back out — they stop doing anything useful and are just
-complexity to maintain.
 
 ## Per-CI-provider note
 
 This specific automated mode is GitHub Actions-only — `claude-code-action` is
 a GitHub Action. On another CI provider, the standalone mode (run the
 `/guider` commands interactively, or script the Claude Code CLI directly in
-whatever job runner you have) still works fine; only the "auto-comment on
-every PR via this exact plugin action" convenience is GitHub-specific.
+whatever job runner you have — installing the skill the same way, with the
+`@adrianfsf/guider` CLI) still works fine; only the "auto-comment on every PR
+via this exact action" convenience is GitHub-specific.

--- a/skill-src/guider/references/init-flow.md
+++ b/skill-src/guider/references/init-flow.md
@@ -141,12 +141,12 @@ Cover these, skipping any the scan already answered:
 (this specific mode is GitHub-specific; see `ci-automation.md`)
 - Want `/guider audit` to run automatically on every PR and post the findings
   as a comment, instead of (or in addition to) running it by hand? If yes,
-  gather the four things `ci-automation.md`'s template needs: which auth
-  secret they'll use (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`), the
-  marketplace repo + name this session's `guider` was actually loaded from,
+  gather the three things `ci-automation.md`'s template needs: which auth
+  secret they'll use (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`),
   whether this repo has bot-opened PRs (and if so, the bot's name), and where
-  its other workflows live. If no, skip the rest of this round entirely — it's
-  opt-in, not a default.
+  its other workflows live. (The workflow installs `guider` itself from the
+  public CLI — no marketplace or plugin to configure.) If no, skip the rest of
+  this round entirely — it's opt-in, not a default.
 
 **API documentation**
 - If there's an HTTP API and no generated OpenAPI spec (or a hand-written one
@@ -236,10 +236,10 @@ Now write, using the templates in `assets/templates/`. Rules:
    (`ci-automation.md`). Fill `assets/templates/guider-audit.yml.tmpl` from the
    interview answers and write it to the project's workflow directory — keep
    only the one auth line (`anthropic_api_key` or `claude_code_oauth_token`)
-   that matches their answer, delete the `allowed_bots` line entirely if they
-   have no bot-opened PRs, and only add the private-marketplace cross-repo
-   token steps if they confirmed that repo is private. Propose the
-   secret-creation command; never run it or ask for the raw value.
+   that matches their answer, and delete the `allowed_bots` line entirely if
+   they have no bot-opened PRs. The workflow installs the skill from the public
+   CLI, so there's nothing else to wire. Propose the secret-creation command;
+   never run it or ask for the raw value.
 
 Finish with a short summary: the files created/edited, the commands the user
 should run to activate the gates (install hooks, enable CI, add the secret if


### PR DESCRIPTION
Closes #3.

The optional `/guider audit` CI workflow (merged in #1) assumed guider was a Claude Code **plugin** loaded from a **marketplace**. It isn't — guider ships as a **skill installed by the `@adrianfsf/guider` CLI** from a public release asset. This reconciles the feature with the real distribution model.

## Verified first (claude-code-action)
- `claude-code-action@v1` **auto-discovers skills** in the workspace's `.claude/skills/` — just `checkout` first and invoke `/skill-name`.
- `actions/checkout@v7` **is** the current tag (so that pin was fine — kept).
- `id-token: write` is **not** required to comment on a PR (GitHub App auth, not OIDC) — **removed**.

## Changes
- **`guider-audit.yml.tmpl`**: drop `plugin_marketplaces`/`plugins` and the private-marketplace token steps; add `npx -y @adrianfsf/guider@latest skills install guider --project`; tighten `permissions` (drop `id-token: write`); invoke `/guider audit` (not `/guider:guider audit`).
- **`ci-automation.md`**: document the CLI-install model; remove the marketplace + private-repo sections; fix the dangling README "How to install it" reference; note `id-token` isn't needed.
- **`init-flow.md`**: Phase 3 gathers **three** answers (no marketplace repo/name); Phase 5 step 9 drops the private-marketplace steps.

## Ship
- Skill content only — **CLI code unchanged**. Bumps to **1.2.1** for tag/asset coherence; an npm republish is optional (the CLI is byte-identical to 1.2.0).
- After squash-merge: rebuild + cut release **v1.2.1** with the new `guider.skill`.

## Tests
`npm test` — **27/27**. Build: 21 entries, 51.2 kB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)